### PR TITLE
Show artist thumbnails in search

### DIFF
--- a/public/css/input.css
+++ b/public/css/input.css
@@ -168,6 +168,10 @@
   .album-cover {
     @apply w-full h-full object-cover;
   }
+
+  .artist-thumbnail {
+    @apply w-full h-full object-cover;
+  }
   
   .album-cover-placeholder {
     @apply w-full h-full flex items-center justify-center text-gray-500;

--- a/src/routes/api.js
+++ b/src/routes/api.js
@@ -7,6 +7,7 @@ const { ensureAuthenticated } = require('../middleware/auth');
 const { logActivity } = require('../services/activity');
 const { searchArtist, searchAlbumsByArtist, searchAlbumsDirect } = require('../services/musicbrainz');
 const { fetchCoverArt } = require('../services/coverArt');
+const { fetchArtistImage } = require('../services/artistImage');
 const { generateAlbumId } = require('../utils/helpers');
 
 // Get all lists for user
@@ -188,6 +189,24 @@ router.post('/cover-art', ensureAuthenticated, async (req, res) => {
   } catch (error) {
     console.error('Cover art fetch error:', error);
     res.status(500).json({ error: 'Failed to fetch cover art' });
+  }
+});
+
+// Fetch artist image
+router.post('/artist-image', ensureAuthenticated, async (req, res) => {
+  const { artist } = req.body;
+
+  try {
+    const imageUrl = await fetchArtistImage(artist);
+
+    if (imageUrl) {
+      res.json({ url: imageUrl });
+    } else {
+      res.status(404).json({ error: 'Image not found' });
+    }
+  } catch (error) {
+    console.error('Artist image fetch error:', error);
+    res.status(500).json({ error: 'Failed to fetch artist image' });
   }
 });
 

--- a/src/services/artistImage.js
+++ b/src/services/artistImage.js
@@ -1,0 +1,49 @@
+const https = require('https');
+
+// Keep connections alive
+const httpsAgent = new https.Agent({ keepAlive: true });
+
+const searchDeezerArtist = (artist) => {
+  return new Promise((resolve) => {
+    const query = encodeURIComponent(artist);
+    const options = {
+      hostname: 'api.deezer.com',
+      path: `/search/artist?q=${query}&limit=1`,
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json'
+      },
+      agent: httpsAgent
+    };
+
+    const req = https.request(options, (res) => {
+      let data = '';
+
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+
+      res.on('end', () => {
+        try {
+          const results = JSON.parse(data);
+          if (results.data && results.data.length > 0) {
+            resolve(results.data[0].picture_big || results.data[0].picture_medium);
+          } else {
+            resolve(null);
+          }
+        } catch (error) {
+          resolve(null);
+        }
+      });
+    });
+
+    req.on('error', () => resolve(null));
+    req.end();
+  });
+};
+
+const fetchArtistImage = async (artist) => {
+  return await searchDeezerArtist(artist);
+};
+
+module.exports = { fetchArtistImage };


### PR DESCRIPTION
## Summary
- support fetching artist images from Deezer
- expose `/api/artist-image` route
- render artist thumbnails in Add Album search modal
- lazy-load artist thumbnails on the client
- add artist-thumbnail styling

## Testing
- `npm run build:css`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840b489e7fc832fbb192619fdebbcb4