### PR TITLE
Fix backup and deduplicate utilities

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -225,10 +225,3 @@ function initializeUserSearch() {
     }, 300);
   });
 }
-
-// Helper to escape HTML
-function escapeHtml(text) {
-  const div = document.createElement('div');
-  div.textContent = text;
-  return div.innerHTML;
-}

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -666,12 +666,6 @@ function showToast(message, type = 'success') {
   }, 3000);
 }
 
-// Escape HTML
-function escapeHtml(text) {
-  const div = document.createElement('div');
-  div.textContent = text;
-  return div.innerHTML;
-}
 
 // Log activity
 async function logActivity(action, details = {}) {

--- a/public/js/utils.js
+++ b/public/js/utils.js
@@ -1,0 +1,6 @@
+function escapeHtml(text) {
+  const div = document.createElement('div');
+  div.textContent = text;
+  return div.innerHTML;
+}
+window.escapeHtml = escapeHtml;

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -189,19 +189,17 @@ router.get('/user-lists/:userId', ensureAdmin, async (req, res) => {
 // Database backup
 router.get('/backup', ensureAdmin, async (req, res) => {
   try {
+    const users = await User.findAll();
+    const lists = db.prepare('SELECT * FROM lists').all();
+    const activity = db.prepare('SELECT * FROM activity').all();
+
     const backup = {
       timestamp: new Date().toISOString(),
       version: '1.0.0',
       data: {
-        users: await new Promise((resolve, reject) => {
-          db.users.find({}, (err, docs) => err ? reject(err) : resolve(docs));
-        }),
-        lists: await new Promise((resolve, reject) => {
-          db.lists.find({}, (err, docs) => err ? reject(err) : resolve(docs));
-        }),
-        activity: await new Promise((resolve, reject) => {
-          db.activity.find({}, (err, docs) => err ? reject(err) : resolve(docs));
-        })
+        users,
+        lists,
+        activity
       }
     };
     

--- a/views/layouts/main.ejs
+++ b/views/layouts/main.ejs
@@ -21,6 +21,9 @@
   <link rel="stylesheet" href="/css/output.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css">
 
+  <!-- Global helpers -->
+  <script src="/js/utils.js"></script>
+
 </head>
 <body class="bg-black text-white min-h-screen">
   <%- body %>


### PR DESCRIPTION
## Summary
- share `escapeHtml` helper across frontend scripts
- clean up unused duplicate `escapeHtml` functions
- fix admin DB backup to use SQLite queries

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684135bf01f4832f851d6ffb54ca3eb3