### PR TITLE
Improve add album search UX

### DIFF
--- a/public/js/albums.js
+++ b/public/js/albums.js
@@ -15,6 +15,7 @@ let searchCoverObserver = null;
 const searchCoverCache = new Map();
 let artistImageObserver = null;
 const artistImageCache = new Map();
+const artistPlaceholder = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI0MCIgaGVpZ2h0PSI0MCIgZmlsbD0iIzU1NSIgdmlld0JveD0iMCAwIDI0IDI0Ij48cGF0aCBkPSJNMTIgMmE1IDUgMCAxMTAgMTAgNSA1IDAgMDEwLTEwem0wIDEyYy0zLjg2NiAwLTcgMy4xMzQtNyA3aDJhNSA1IDAgMDExMCAwaDJjMC0zLjg2Ni0zLjEzNC03LTctN3oiLz48L3N2Zz4K';
 
 // Toggle search mode
 searchModeToggle?.addEventListener('click', () => {
@@ -149,6 +150,10 @@ function clearArtistSelection() {
 
 function displayAlbumResults(albums, artistName = null) {
   albumResults.classList.remove('hidden');
+
+  // Remove loading spinner if it exists
+  const spinner = artistResults.querySelector('.fa-spinner');
+  if (spinner) spinner.parentElement.remove();
   
   if (albums.length === 0) {
     albumResults.innerHTML = '<p class="text-gray-500 text-center py-4">No albums found</p>';
@@ -618,6 +623,10 @@ function initializeArtistImageObserver() {
             artistImageCache.set(cacheKey, base64);
             img.src = base64;
             img.onload = () => img.classList.add('loaded');
+          } else {
+            artistImageCache.set(cacheKey, artistPlaceholder);
+            img.src = artistPlaceholder;
+            img.classList.add('loaded');
           }
         }
         artistImageObserver.unobserve(img);

--- a/views/partials/modals/add-album.ejs
+++ b/views/partials/modals/add-album.ejs
@@ -24,14 +24,17 @@
               <i class="fas fa-user mr-1"></i>Artist Search
             </button>
             <div class="flex-1 relative">
-              <input type="text" id="album-search-input" 
-                     class="input-dark w-full pr-10" 
+              <input type="text" id="album-search-input"
+                     class="input-dark w-full pr-10"
                      placeholder="Search for an artist...">
               <button id="search-button" class="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white">
                 <i class="fas fa-search"></i>
               </button>
             </div>
           </div>
+          <p class="text-xs text-gray-500 mt-2">
+            Use the button above to switch between artist and album search.
+          </p>
         </div>
         
         <!-- Search results -->


### PR DESCRIPTION
## Summary
- clarify that the search button toggles between artist/album search
- remove spinner after album results are loaded
- use a placeholder image when artist thumbnails are missing

## Testing
- `npm run build:css` *(fails: postcss not found)*

------
https://chatgpt.com/codex/tasks/task_e_68413ad92784832fa4e57e4a64e9c3a4