### PR TITLE
Improve admin dashboard

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -155,6 +155,25 @@ async function clearAllSessions() {
   }
 }
 
+// Clean old activity logs
+async function cleanLogs() {
+  if (!confirm('Remove old activity logs?')) return;
+
+  try {
+    const response = await fetch('/admin/clean-logs', { method: 'POST' });
+
+    if (response.ok) {
+      const data = await response.json();
+      alert(`Removed ${data.removed} log entries`);
+    } else {
+      throw new Error('Failed to clean logs');
+    }
+  } catch (error) {
+    console.error('Clean logs error:', error);
+    alert('Failed to clean logs');
+  }
+}
+
 // Activity stream
 function startActivityStream() {
   const activityContainer = document.getElementById('activity-stream');
@@ -198,8 +217,17 @@ async function refreshStats() {
 
     // Update stat cards
     document.getElementById('total-users').textContent = stats.totalUsers;
+    if (document.getElementById('new-users')) {
+      document.getElementById('new-users').textContent = stats.newUsers7d;
+    }
     document.getElementById('total-lists').textContent = stats.totalLists;
+    if (document.getElementById('new-lists')) {
+      document.getElementById('new-lists').textContent = stats.newLists7d;
+    }
     document.getElementById('total-albums').textContent = stats.totalAlbums;
+    if (document.getElementById('db-size')) {
+      document.getElementById('db-size').textContent = `${stats.dbSizeMB} MB`;
+    }
     document.getElementById('active-users').textContent = stats.activeUsers;
     if (document.getElementById('memory-usage')) {
       document.getElementById('memory-usage').textContent = `${stats.memoryUsageMB} MB`;
@@ -209,6 +237,9 @@ async function refreshStats() {
     }
     if (document.getElementById('cpu-load')) {
       document.getElementById('cpu-load').textContent = stats.loadAvg1;
+    }
+    if (document.getElementById('node-version')) {
+      document.getElementById('node-version').textContent = stats.nodeVersion;
     }
   } catch (error) {
     console.error('Stats refresh error:', error);

--- a/src/models/List.js
+++ b/src/models/List.js
@@ -92,6 +92,12 @@ class List {
     const result = stmt.get(userId);
     return result.count;
   }
+
+  static countCreatedSince(dateIso) {
+    const stmt = db.prepare('SELECT COUNT(*) as count FROM lists WHERE createdAt >= ?');
+    const result = stmt.get(dateIso);
+    return result.count;
+  }
   
   static async getStats() {
     const stmt = db.prepare('SELECT COUNT(*) as totalLists FROM lists');

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -100,6 +100,12 @@ class User {
     stmt.run(token, expiresStr, new Date().toISOString(), email.toLowerCase());
     return this.findByEmail(email);
   }
+
+  static countSince(dateIso) {
+    const stmt = db.prepare('SELECT COUNT(*) as count FROM users WHERE createdAt >= ?');
+    const result = stmt.get(dateIso);
+    return result.count;
+  }
 }
 
 module.exports = User;

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -19,36 +19,60 @@
     </div>
   </header>
   
-  <div id="admin-panel" class="max-w-7xl mx-auto p-4 lg:p-6 space-y-8">
-    <!-- Stats Cards -->
-    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-7 gap-4">
-      <div class="bg-gray-900 rounded-lg p-4">
-        <div class="text-2xl font-bold" id="total-users"><%= stats.totalUsers %></div>
-        <div class="text-sm text-gray-400">Total Users</div>
+  <div id="admin-panel" class="max-w-7xl mx-auto p-4 lg:p-6 space-y-12">
+    <div>
+      <h2 class="text-lg font-semibold mb-2">User Statistics</h2>
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+        <div class="bg-gray-900 rounded-lg p-4">
+          <div class="text-2xl font-bold" id="total-users"><%= stats.totalUsers %></div>
+          <div class="text-sm text-gray-400">Total Users</div>
+        </div>
+        <div class="bg-gray-900 rounded-lg p-4">
+          <div class="text-2xl font-bold" id="new-users"><%= stats.newUsers7d %></div>
+          <div class="text-sm text-gray-400">New Users (7d)</div>
+        </div>
+        <div class="bg-gray-900 rounded-lg p-4">
+          <div class="text-2xl font-bold" id="total-lists"><%= stats.totalLists %></div>
+          <div class="text-sm text-gray-400">Total Lists</div>
+        </div>
+        <div class="bg-gray-900 rounded-lg p-4">
+          <div class="text-2xl font-bold" id="new-lists"><%= stats.newLists7d %></div>
+          <div class="text-sm text-gray-400">New Lists (7d)</div>
+        </div>
+        <div class="bg-gray-900 rounded-lg p-4">
+          <div class="text-2xl font-bold" id="total-albums"><%= stats.totalAlbums %></div>
+          <div class="text-sm text-gray-400">Total Albums</div>
+        </div>
+        <div class="bg-gray-900 rounded-lg p-4">
+          <div class="text-2xl font-bold" id="active-users"><%= stats.activeUsers %></div>
+          <div class="text-sm text-gray-400">Active Users (7d)</div>
+        </div>
       </div>
-      <div class="bg-gray-900 rounded-lg p-4">
-        <div class="text-2xl font-bold" id="total-lists"><%= stats.totalLists %></div>
-        <div class="text-sm text-gray-400">Total Lists</div>
-      </div>
-      <div class="bg-gray-900 rounded-lg p-4">
-        <div class="text-2xl font-bold" id="total-albums"><%= stats.totalAlbums %></div>
-        <div class="text-sm text-gray-400">Total Albums</div>
-      </div>
-      <div class="bg-gray-900 rounded-lg p-4">
-        <div class="text-2xl font-bold" id="active-users"><%= stats.activeUsers %></div>
-        <div class="text-sm text-gray-400">Active Users (7d)</div>
-      </div>
-      <div class="bg-gray-900 rounded-lg p-4">
-        <div class="text-2xl font-bold" id="memory-usage"><%= stats.memoryUsageMB %> MB</div>
-        <div class="text-sm text-gray-400">Memory Usage</div>
-      </div>
-      <div class="bg-gray-900 rounded-lg p-4">
-        <div class="text-2xl font-bold" id="system-uptime"><%= stats.systemUptimeHrs %></div>
-        <div class="text-sm text-gray-400">Uptime (hrs)</div>
-      </div>
-      <div class="bg-gray-900 rounded-lg p-4">
-        <div class="text-2xl font-bold" id="cpu-load"><%= stats.loadAvg1 %></div>
-        <div class="text-sm text-gray-400">CPU Load</div>
+    </div>
+
+    <div>
+      <h2 class="text-lg font-semibold mb-2">System Statistics</h2>
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+        <div class="bg-gray-900 rounded-lg p-4">
+          <div class="text-2xl font-bold" id="memory-usage"><%= stats.memoryUsageMB %> MB</div>
+          <div class="text-sm text-gray-400">Memory Usage</div>
+        </div>
+        <div class="bg-gray-900 rounded-lg p-4">
+          <div class="text-2xl font-bold" id="db-size"><%= stats.dbSizeMB %> MB</div>
+          <div class="text-sm text-gray-400">DB Size</div>
+        </div>
+        <div class="bg-gray-900 rounded-lg p-4">
+          <div class="text-2xl font-bold" id="system-uptime"><%= stats.systemUptimeHrs %></div>
+          <div class="text-sm text-gray-400">Uptime (hrs)</div>
+        </div>
+        <div class="bg-gray-900 rounded-lg p-4">
+          <div class="text-2xl font-bold" id="cpu-load"><%= stats.loadAvg1 %></div>
+          <div class="text-sm text-gray-400">CPU Load</div>
+        </div>
+        <div class="bg-gray-900 rounded-lg p-4">
+          <div class="text-2xl font-bold" id="node-version"><%= stats.nodeVersion %></div>
+          <div class="text-sm text-gray-400">Node.js Version</div>
+        </div>
       </div>
     </div>
 
@@ -131,9 +155,12 @@
     <!-- System Actions -->
     <div class="bg-gray-900 rounded-lg p-6">
       <h2 class="text-lg font-semibold mb-4">System Actions</h2>
-      <div class="flex gap-3">
+      <div class="flex flex-wrap gap-3">
         <button onclick="clearAllSessions()" class="btn-secondary">
           <i class="fas fa-user-slash mr-2"></i>Clear All Sessions
+        </button>
+        <button onclick="cleanLogs()" class="btn-secondary">
+          <i class="fas fa-broom mr-2"></i>Clean Old Logs
         </button>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add helper to count users created since a date
- add helper to count lists created since a date
- extend admin routes with new statistics and log cleanup
- refresh dashboard stats on the client
- reorganise admin dashboard layout and actions

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841552a0a68832f9b7c39efc057fd96