### PR TITLE
Improve header/sidebar clarity

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -764,6 +764,7 @@ async function checkAdminStatus() {
 
 function initializeMobileMenu() {
   const hamburger = document.getElementById('mobile-menu-btn');
+  const sidebarToggle = document.getElementById('desktop-menu-btn');
   const sidebar = document.getElementById('sidebar');
   const overlay = document.getElementById('mobile-overlay');
   
@@ -781,6 +782,14 @@ function initializeMobileMenu() {
   
   hamburger?.addEventListener('click', () => toggleSidebar(true));
   overlay?.addEventListener('click', () => toggleSidebar(false));
+
+  sidebarToggle?.addEventListener('click', () => {
+    if (window.innerWidth >= 1024) {
+      sidebar.classList.toggle('hidden');
+    } else {
+      toggleSidebar(true);
+    }
+  });
   
   // Close sidebar on list selection on mobile
   if (window.innerWidth < 1024) {

--- a/views/partials/header.ejs
+++ b/views/partials/header.ejs
@@ -1,25 +1,23 @@
-<header class="bg-gray-900 border-b border-gray-800 flex-shrink-0">
+<header class="bg-gray-900 border-b border-gray-800 flex-shrink-0 lg:border-l lg:border-gray-800">
   <div class="flex items-center justify-between p-4">
-    <!-- Mobile menu button -->
-    <button id="mobile-menu-btn" class="lg:hidden text-gray-400 hover:text-white">
-      <i class="fas fa-bars text-xl"></i>
-    </button>
-    
-    <!-- Current list name -->
-    <div class="flex items-center gap-4">
-      <h1 class="font-cinzel text-xl lg:text-2xl font-semibold text-accent glow-text">
-        <span class="hidden lg:inline">SuShe Stargate</span>
-        <span class="lg:hidden">SuShe</span>
-      </h1>
-      <span class="text-gray-400 hidden lg:inline">|</span>
-      <span id="current-list-name" class="text-lg hidden lg:inline"></span>
+    <div class="flex items-center gap-2">
+      <!-- Mobile menu button -->
+      <button id="mobile-menu-btn" class="lg:hidden text-gray-400 hover:text-white">
+        <i class="fas fa-bars text-xl"></i>
+      </button>
+      <!-- Current list name -->
+      <div class="flex items-center gap-4">
+        <h1 class="font-cinzel text-xl lg:text-2xl font-semibold text-accent glow-text">
+          <span class="hidden lg:inline">SuShe Stargate</span>
+          <span class="lg:hidden">SuShe</span>
+        </h1>
+        <span class="text-gray-400 hidden lg:inline">|</span>
+        <span id="current-list-name" class="text-lg hidden lg:inline"></span>
+      </div>
     </div>
-    
+
     <!-- Mobile actions -->
     <div class="flex lg:hidden items-center gap-3">
-      <div class="text-gray-500 text-xs" id="reorder-hint">
-        <i class="fas fa-hand-pointer"></i>
-      </div>
       <button id="settings-btn" class="text-gray-400 hover:text-white">
         <i class="fas fa-cog text-xl"></i>
       </button>

--- a/views/partials/sidebar.ejs
+++ b/views/partials/sidebar.ejs
@@ -1,8 +1,7 @@
 <div class="flex flex-col h-full">
-  <div class="p-4 border-b border-gray-800">
-    <h2 class="text-lg font-semibold mb-3">My Lists</h2>
-    <button id="create-list-btn" class="btn-primary w-full">
-      <i class="fas fa-plus mr-2"></i>Create List
+  <div class="p-4 border-b border-gray-800 flex justify-end">
+    <button id="desktop-menu-btn" class="hidden lg:block text-gray-400 hover:text-white">
+      <i class="fas fa-bars"></i>
     </button>
   </div>
 
@@ -13,6 +12,9 @@
   </div>
 
   <div class="p-4 border-t border-gray-800 space-y-2">
+    <button id="create-list-btn" class="w-full text-left px-3 py-2 hover:bg-gray-800 rounded">
+      <i class="fas fa-plus mr-2"></i>Create List
+    </button>
     <button id="import-btn" class="w-full text-left px-3 py-2 hover:bg-gray-800 rounded">
       <i class="fas fa-upload mr-2"></i>Import List
     </button>


### PR DESCRIPTION
## Summary
- move desktop sidebar toggle into sidebar
- relocate create list button with other actions
- cleanup header markup

## Testing
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_68415db8e398832fa91663d977f2ace4